### PR TITLE
Version bump to 1.0.1-SNAPSHOT and update build.gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ gradle/
 
 /.apt_generated/
 /bin/
+/src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'io.github.mariohct'
-version '1.0-SNAPSHOT'
+version '1.0.1-SNAPSHOT'
 
 apply plugin: "java"
 apply plugin: "jacoco"
@@ -96,6 +96,10 @@ task sourcesJar(type: Jar, dependsOn: classes) {
 task javadocJar(type: Jar, dependsOn: javadoc) {
         classifier = 'javadoc'
         from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
 }
 
 dependencies {


### PR DESCRIPTION
Version bump to 1.0.1-SNAPSHOT. This version is uploaded to agentwise maven repo and it works with BeSwarm.