### PR TITLE
Update introduction act to work with new map configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
     group 'io.github.agentwise.swarmview'
-    version = '1.1-SNAPSHOT'
+    version = '1.1.7'
 
     apply plugin: "eclipse"
     apply plugin: "java"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 allprojects {
     group 'io.github.agentwise.swarmview'
-    version = '1.1.7'
+    version = '1.1.8'
 
     apply plugin: "eclipse"
     apply plugin: "java"

--- a/trajectory/src/main/java/io/github/agentwise/swarmview/trajectory/rats/OTIntroAct.java
+++ b/trajectory/src/main/java/io/github/agentwise/swarmview/trajectory/rats/OTIntroAct.java
@@ -7,7 +7,7 @@ import io.github.agentwise.swarmview.trajectory.control.ChoreographyView;
 import io.github.agentwise.swarmview.trajectory.control.DroneName;
 import io.github.agentwise.swarmview.trajectory.control.DronePositionConfiguration;
 import io.github.agentwise.swarmview.trajectory.control.dto.Pose;
-import io.github.agentwise.swarmview.trajectory.operationaltests.BasicCirclesAct;
+import io.github.agentwise.swarmview.trajectory.rats.acts.introduction.IntroductionAct;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,23 +38,14 @@ public final class OTIntroAct {
     config = ActConfiguration.create("IntroAct", introPositions);
   }
 
-  public static ChoreographyView createCircleChoreography() {
-    Act circle = BasicCirclesAct.create(config);
-    circle.lockAndBuild();
+  public static ChoreographyView createIntroChoreography() {
+    final Act introAct = IntroductionAct.create(config);
+    introAct.lockAndBuild();
 
     final Choreography choreo =
-        Choreography.create(DroneName.Nerve, DroneName.Romeo, DroneName.Juliet, DroneName.Fievel);
-    choreo.addAct(circle);
-    return choreo;
-  }
-
-  public static ChoreographyView createUpDown() {
-    Act circle = BasicCirclesAct.create(config);
-    circle.lockAndBuild();
-
-    final Choreography choreo =
-        Choreography.create(DroneName.Nerve, DroneName.Romeo, DroneName.Juliet, DroneName.Fievel);
-    choreo.addAct(circle);
+        Choreography.create(
+            DroneName.Nerve, DroneName.Romeo, DroneName.Juliet, DroneName.Fievel, DroneName.Dumbo);
+    choreo.addAct(introAct);
     return choreo;
   }
 }

--- a/trajectory/src/main/java/io/github/agentwise/swarmview/trajectory/rats/OTIntroAct.java
+++ b/trajectory/src/main/java/io/github/agentwise/swarmview/trajectory/rats/OTIntroAct.java
@@ -1,0 +1,60 @@
+package io.github.agentwise.swarmview.trajectory.rats;
+
+import io.github.agentwise.swarmview.trajectory.control.Act;
+import io.github.agentwise.swarmview.trajectory.control.ActConfiguration;
+import io.github.agentwise.swarmview.trajectory.control.Choreography;
+import io.github.agentwise.swarmview.trajectory.control.ChoreographyView;
+import io.github.agentwise.swarmview.trajectory.control.DroneName;
+import io.github.agentwise.swarmview.trajectory.control.DronePositionConfiguration;
+import io.github.agentwise.swarmview.trajectory.control.dto.Pose;
+import io.github.agentwise.swarmview.trajectory.operationaltests.BasicCirclesAct;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** @author Hoang Tung Dinh */
+public final class OTIntroAct {
+  public static final double YAW = -Math.PI / 2.0;
+  private static ActConfiguration config;
+
+  static {
+    final List<DronePositionConfiguration> introPositions = new ArrayList<>();
+    introPositions.add(
+        DronePositionConfiguration.create(
+            DroneName.Nerve, Pose.create(6.7, 5.0, 1.0, 0.0), Pose.create(2.0, 0.0, 3.5, 0.0)));
+    introPositions.add(
+        DronePositionConfiguration.create(
+            DroneName.Romeo, Pose.create(5.0, 5.0, 1.0, 0.0), Pose.create(1.1, 5.0, 1.0, 0.0)));
+    introPositions.add(
+        DronePositionConfiguration.create(
+            DroneName.Juliet, Pose.create(1.0, 4.0, 1.0, 0.0), Pose.create(6.7, 5.0, 1.0, 0.0)));
+    introPositions.add(
+        DronePositionConfiguration.create(
+            DroneName.Fievel, Pose.create(1.0, 5.1, 1.0, 0.0), Pose.create(5.0, 2.5, 1.0, 0.0)));
+    introPositions.add(
+        DronePositionConfiguration.create(
+            DroneName.Dumbo, Pose.create(6.7, 3.0, 1.0, 0.0), Pose.create(4.0, 3.5, 2.5, 0.0)));
+
+    config = ActConfiguration.create("IntroAct", introPositions);
+  }
+
+  public static ChoreographyView createCircleChoreography() {
+    Act circle = BasicCirclesAct.create(config);
+    circle.lockAndBuild();
+
+    final Choreography choreo =
+        Choreography.create(DroneName.Nerve, DroneName.Romeo, DroneName.Juliet, DroneName.Fievel);
+    choreo.addAct(circle);
+    return choreo;
+  }
+
+  public static ChoreographyView createUpDown() {
+    Act circle = BasicCirclesAct.create(config);
+    circle.lockAndBuild();
+
+    final Choreography choreo =
+        Choreography.create(DroneName.Nerve, DroneName.Romeo, DroneName.Juliet, DroneName.Fievel);
+    choreo.addAct(circle);
+    return choreo;
+  }
+}

--- a/trajectory/src/main/java/io/github/agentwise/swarmview/trajectory/rats/OTIntroAct.java
+++ b/trajectory/src/main/java/io/github/agentwise/swarmview/trajectory/rats/OTIntroAct.java
@@ -21,19 +21,19 @@ public final class OTIntroAct {
     final List<DronePositionConfiguration> introPositions = new ArrayList<>();
     introPositions.add(
         DronePositionConfiguration.create(
-            DroneName.Nerve, Pose.create(6.7, 5.0, 1.0, 0.0), Pose.create(2.0, 0.0, 3.5, 0.0)));
+            DroneName.Nerve, Pose.create(6.7, 5.0, 1.0, YAW), Pose.create(2.0, 0.0, 3.5, YAW)));
     introPositions.add(
         DronePositionConfiguration.create(
-            DroneName.Romeo, Pose.create(5.0, 5.0, 1.0, 0.0), Pose.create(1.1, 5.0, 1.0, 0.0)));
+            DroneName.Romeo, Pose.create(5.0, 5.0, 1.0, YAW), Pose.create(1.1, 5.0, 1.0, YAW)));
     introPositions.add(
         DronePositionConfiguration.create(
-            DroneName.Juliet, Pose.create(1.0, 4.0, 1.0, 0.0), Pose.create(6.7, 5.0, 1.0, 0.0)));
+            DroneName.Juliet, Pose.create(1.0, 4.0, 1.0, YAW), Pose.create(6.7, 5.0, 1.0, YAW)));
     introPositions.add(
         DronePositionConfiguration.create(
-            DroneName.Fievel, Pose.create(1.0, 5.1, 1.0, 0.0), Pose.create(5.0, 2.5, 1.0, 0.0)));
+            DroneName.Fievel, Pose.create(1.0, 5.1, 1.0, YAW), Pose.create(5.0, 2.5, 1.0, YAW)));
     introPositions.add(
         DronePositionConfiguration.create(
-            DroneName.Dumbo, Pose.create(6.7, 3.0, 1.0, 0.0), Pose.create(4.0, 3.5, 2.5, 0.0)));
+            DroneName.Dumbo, Pose.create(6.7, 3.0, 1.0, YAW), Pose.create(4.0, 3.5, 2.5, YAW)));
 
     config = ActConfiguration.create("IntroAct", introPositions);
   }

--- a/trajectory/src/main/java/io/github/agentwise/swarmview/trajectory/rats/OTTamingAct.java
+++ b/trajectory/src/main/java/io/github/agentwise/swarmview/trajectory/rats/OTTamingAct.java
@@ -1,0 +1,51 @@
+package io.github.agentwise.swarmview.trajectory.rats;
+
+import io.github.agentwise.swarmview.trajectory.control.Act;
+import io.github.agentwise.swarmview.trajectory.control.ActConfiguration;
+import io.github.agentwise.swarmview.trajectory.control.Choreography;
+import io.github.agentwise.swarmview.trajectory.control.ChoreographyView;
+import io.github.agentwise.swarmview.trajectory.control.DroneName;
+import io.github.agentwise.swarmview.trajectory.control.DronePositionConfiguration;
+import io.github.agentwise.swarmview.trajectory.control.dto.Pose;
+import io.github.agentwise.swarmview.trajectory.rats.acts.taming.TamingAct;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** @author Hoang Tung Dinh */
+public final class OTTamingAct {
+  public static final double YAW = -Math.PI / 2.0;
+  private static ActConfiguration config;
+
+  static {
+    List<DronePositionConfiguration> tamingPositions = new ArrayList<>();
+    tamingPositions.add(
+        DronePositionConfiguration.create(
+            DroneName.Nerve, Pose.create(4.5, 1.0, 2.0, 0.0), Pose.create(1.36, 1.0, 3.5, 0.0)));
+    tamingPositions.add(
+        DronePositionConfiguration.create(
+            DroneName.Romeo, Pose.create(3.5, 1.0, 2.5, 0.0), Pose.create(2.42, 2.0, 2.9, 0.0)));
+    tamingPositions.add(
+        DronePositionConfiguration.create(
+            DroneName.Juliet, Pose.create(2.0, 3.55, 2.0, 0.0), Pose.create(3.48, 3.0, 2.3, 0.0)));
+    tamingPositions.add(
+        DronePositionConfiguration.create(
+            DroneName.Fievel, Pose.create(5.0, 4, 2.5, 0.0), Pose.create(4.54, 4.0, 1.7, 0.0)));
+    tamingPositions.add(
+        DronePositionConfiguration.create(
+            DroneName.Dumbo, Pose.create(3.0, 4.1, 1.0, 0.0), Pose.create(5.6, 5.0, 1.0, 0.0)));
+
+    config = ActConfiguration.create("TammingAct", tamingPositions);
+  }
+
+  public static ChoreographyView createTamingChoreography() {
+    final Act tamingAct = TamingAct.create(config);
+    tamingAct.lockAndBuild();
+
+    final Choreography choreo =
+        Choreography.create(
+            DroneName.Nerve, DroneName.Romeo, DroneName.Juliet, DroneName.Fievel, DroneName.Dumbo);
+    choreo.addAct(tamingAct);
+    return choreo;
+  }
+}

--- a/trajectory/src/main/java/io/github/agentwise/swarmview/trajectory/rats/OTTamingAct.java
+++ b/trajectory/src/main/java/io/github/agentwise/swarmview/trajectory/rats/OTTamingAct.java
@@ -21,19 +21,19 @@ public final class OTTamingAct {
     List<DronePositionConfiguration> tamingPositions = new ArrayList<>();
     tamingPositions.add(
         DronePositionConfiguration.create(
-            DroneName.Nerve, Pose.create(4.5, 1.0, 2.0, 0.0), Pose.create(1.36, 1.0, 3.5, 0.0)));
+            DroneName.Nerve, Pose.create(4.5, 1.0, 2.0, YAW), Pose.create(1.36, 1.0, 3.5, YAW)));
     tamingPositions.add(
         DronePositionConfiguration.create(
-            DroneName.Romeo, Pose.create(3.5, 1.0, 2.5, 0.0), Pose.create(2.42, 2.0, 2.9, 0.0)));
+            DroneName.Romeo, Pose.create(3.5, 1.0, 2.5, YAW), Pose.create(2.42, 2.0, 2.9, YAW)));
     tamingPositions.add(
         DronePositionConfiguration.create(
-            DroneName.Juliet, Pose.create(2.0, 3.55, 2.0, 0.0), Pose.create(3.48, 3.0, 2.3, 0.0)));
+            DroneName.Juliet, Pose.create(2.0, 3.55, 2.0, YAW), Pose.create(3.48, 3.0, 2.3, YAW)));
     tamingPositions.add(
         DronePositionConfiguration.create(
-            DroneName.Fievel, Pose.create(5.0, 4, 2.5, 0.0), Pose.create(4.54, 4.0, 1.7, 0.0)));
+            DroneName.Fievel, Pose.create(5.0, 4, 2.5, YAW), Pose.create(4.54, 4.0, 1.7, YAW)));
     tamingPositions.add(
         DronePositionConfiguration.create(
-            DroneName.Dumbo, Pose.create(3.0, 4.1, 1.0, 0.0), Pose.create(5.6, 5.0, 1.0, 0.0)));
+            DroneName.Dumbo, Pose.create(3.0, 4.1, 1.0, YAW), Pose.create(5.6, 5.0, 1.0, YAW)));
 
     config = ActConfiguration.create("TammingAct", tamingPositions);
   }

--- a/trajectory/src/main/java/io/github/agentwise/swarmview/trajectory/rats/acts/introduction/DumboIntroduction.java
+++ b/trajectory/src/main/java/io/github/agentwise/swarmview/trajectory/rats/acts/introduction/DumboIntroduction.java
@@ -24,8 +24,8 @@ public class DumboIntroduction {
 		
 		double[][] path = {
 					{ 	4, 4, 1.5,		3, 1, 4, 0.5 },	// wiggle position, number of wiggles, time to stay at edge, number of zigzags to get there, distance of zigzags
-					{ 	6, 5, 1,		2, 1, 8, 0.6 },	// wiggle position, number of wiggles, time to stay at edge, number of zigzags to get there, distance of zigzags
-					{ 	2, 5, 2,		2, 1, 6, 0.8 },	// wiggle position, number of wiggles, time to stay at edge, number of zigzags to get there, distance of zigzags
+					{ 	6, 4, 1,		2, 1, 8, 0.6 },	// wiggle position, number of wiggles, time to stay at edge, number of zigzags to get there, distance of zigzags
+					{ 	2, 4, 2,		2, 1, 6, 0.8 },	// wiggle position, number of wiggles, time to stay at edge, number of zigzags to get there, distance of zigzags
 			};
 		
 		TrajectoryComposite.Builder trajectoryBuilder = TrajectoryComposite.builder();

--- a/trajectory/src/main/java/io/github/agentwise/swarmview/trajectory/rats/acts/introduction/FievelIntroduction.java
+++ b/trajectory/src/main/java/io/github/agentwise/swarmview/trajectory/rats/acts/introduction/FievelIntroduction.java
@@ -28,10 +28,10 @@ public class FievelIntroduction {
 		double[][] path = {
 					{ 	4, 4, 2,		 0.4,  0.45,	1, 0 },	// mid point pendulum, frequency, radius, revolutions, direction
 					{ 	4.1, 4, 2,		 0.4,  0.45,	1, Math.PI },	// mid point pendulum, frequency, radius, revolutions, direction
-					{ 	4, 3.5, 2.5,	 0.3,  1,		2, Math.PI*3/4 },
+					{ 	4, 2.5, 2.5,	 0.3,  1,		2, Math.PI*3/4 },
 					// { 	4, 2, 3,	 0.18, 1.2,		1, Math.PI },
-					{ 	5, 5, 2,		 0.4,  0.5,		1, Math.PI*1.25 },
-					{ 	5.1, 5, 2,		 0.4,  0.5,		1, 2*Math.PI-Math.PI*1.25 },
+					{ 	5, 3, 2,		 0.4,  0.5,		1, Math.PI*1.25 },
+					{ 	5.1, 3, 2,		 0.4,  0.5,		1, 2*Math.PI-Math.PI*1.25 },
 			};
 		
 		Point4D currentPosition = Point4D.from(initialPose);

--- a/trajectory/src/main/java/io/github/agentwise/swarmview/trajectory/rats/acts/introduction/NerveTrajectoryIntroduction.java
+++ b/trajectory/src/main/java/io/github/agentwise/swarmview/trajectory/rats/acts/introduction/NerveTrajectoryIntroduction.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package io.github.agentwise.swarmview.trajectory.rats.acts.introduction;
 
@@ -15,7 +15,7 @@ import io.github.agentwise.swarmview.trajectory.control.dto.Pose;
  *
  */
 public class NerveTrajectoryIntroduction implements FiniteTrajectory4d {
-	
+
 	private double duration;
 	private FiniteTrajectory4d trajectory;
 
@@ -30,54 +30,55 @@ public class NerveTrajectoryIntroduction implements FiniteTrajectory4d {
 		double yaw = -Math.PI/2;
 		double[][] path = {
 				{ 	initialPosition.x(),	initialPosition.y(), 		initialPosition.z(),  	yaw, 1.0 },	// start position, start time is ignored
-				{    mid +  -0.06 , depth +  0.0 ,  heigh  +  0.04 , yaw +  0.07 , speed +  0.12 } , 
-				{    mid +  0.21 , depth +  0.02 ,  low  +  0.07 , yaw +  0.09 , speed +  0.12 } , 
-				{    mid +  -0.08 , depth +  0.02 ,  heigh  +  0.07 , yaw +  -0.17 , speed +  -0.09 } , 
-				{    mid +  0.21 , depth +  0.01 ,  low  +  0.0 , yaw +  -0.08 , speed +  0.18 } , 
-				{    mid +  0.02 , depth +  -0.07 ,  heigh  +  -0.11 , yaw +  0.11 , speed +  0.0 } , 
-				{    mid +  0.14 , depth +  -0.1 ,  low  +  -0.03 , yaw +  -0.02 , speed +  0.02 } , 
-				{    mid +  -0.05 , depth +  -0.12 ,  heigh  +  0.17 , yaw +  0.15 , speed +  -0.16 } , 
-				{    mid +  -0.09 , depth +  -0.07 ,  low  +  0.08 , yaw +  -0.15 , speed +  -0.14 } , 
-				{    mid +  0.22 , depth +  -0.06 ,  heigh  +  -0.06 , yaw +  0.04 , speed +  0.18 } , 
-				{    mid +  0.03 , depth +  0.19 ,  low  +  0.19 , yaw +  -0.04 , speed +  0.19 } , 
-				{    mid +  -0.26 , depth +  0.0 ,  heigh  +  0.01 , yaw +  0.03 , speed +  0.08 } , 
-				{    mid +  -0.09 , depth +  -0.19 ,  low  +  -0.11 , yaw +  -0.17 , speed +  -0.05 } , 
-				{    mid +  0.28 , depth +  0.03 ,  heigh  +  0.15 , yaw +  -0.12 , speed +  0.09 } , 
-				{    mid +  -0.01 , depth +  0.15 ,  low  +  -0.14 , yaw +  0.05 , speed +  0.02 } , 
-				{    mid +  -0.02 , depth +  -0.12 ,  heigh  +  -0.12 , yaw +  -0.06 , speed +  0.01 } , 
-				{    mid +  -0.26 , depth +  -0.11 ,  low  +  -0.06 , yaw +  0.08 , speed +  0.06 } , 
-				{    mid +  0.09 , depth +  -0.12 ,  heigh  +  -0.14 , yaw +  0.0 , speed +  0.09 } , 
-				{    mid +  0.1 , depth +  0.01 ,  low  +  -0.01 , yaw +  0.19 , speed +  -0.04 } , 
-				{    mid +  0.12 , depth +  -0.13 ,  heigh  +  0.15 , yaw +  -0.04 , speed +  0.12 } , 
-				{    mid +  0.03 , depth +  -0.11 ,  low  +  0.18 , yaw +  0.09 , speed +  -0.11 } , 
-				{    mid +  -0.28 , depth +  0.0 ,  heigh  +  0.07 , yaw +  -0.05 , speed +  -0.12 } , 
-				{    mid +  0.29 , depth +  -0.02 ,  low  +  0.06 , yaw +  -0.02 , speed +  0.01 } , 
-				{    mid +  -0.28 , depth +  0.13 ,  heigh  +  0.09 , yaw +  0.15 , speed +  -0.18 } , 
-				{    mid +  -0.19 , depth +  -0.12 ,  low  +  0.04 , yaw +  0.06 , speed +  0.06 } , 
-				{    mid +  0.04 , depth +  -0.2 ,  heigh  +  0.02 , yaw +  -0.02 , speed +  0.04 } , 
-				{    mid +  0.25 , depth +  0.02 ,  low  +  -0.19 , yaw +  -0.04 , speed +  -0.17 } , 
-				{    mid +  -0.28 , depth +  0.11 ,  heigh  +  -0.03 , yaw +  0.08 , speed +  0.1 } , 
-				{    mid +  0.16 , depth +  0.09 ,  low  +  0.08 , yaw +  0.02 , speed +  -0.04 } , 
-				{    mid +  0.17 , depth +  -0.16 ,  heigh  +  -0.05 , yaw +  -0.12 , speed +  0.16 } , 
-				{    mid +  -0.28 , depth +  -0.19 ,  low  +  -0.11 , yaw +  0.06 , speed +  -0.03 } , 
-				{    mid +  -0.03 , depth +  0.11 ,  heigh  +  0.15 , yaw +  0.1 , speed +  0.18 } , 
-				{    mid +  -0.21 , depth +  0.09 ,  low  +  -0.16 , yaw +  -0.19 , speed +  -0.08 } , 				{ 	finalPosition.x(),	finalPosition.y(), 		finalPosition.z(),  	yaw, 0.5 },
+				{    mid +  -0.06 , depth +  0.0 ,  heigh  +  0.04 , yaw +  0.07 , speed +  0.12 } ,
+				{    mid +  0.21 , depth +  0.02 ,  low  +  0.07 , yaw +  0.09 , speed +  0.12 } ,
+				{    mid +  -0.08 , depth +  0.02 ,  heigh  +  0.07 , yaw +  -0.17 , speed +  -0.09 } ,
+				{    mid +  0.21 , depth +  0.01 ,  low  +  0.0 , yaw +  -0.08 , speed +  0.18 } ,
+				{    mid +  0.02 , depth +  -0.07 ,  heigh  +  -0.11 , yaw +  0.11 , speed +  0.0 } ,
+				{    mid +  0.14 , depth +  -0.1 ,  low  +  -0.03 , yaw +  -0.02 , speed +  0.02 } ,
+				{    mid +  -0.05 , depth +  -0.12 ,  heigh  +  0.17 , yaw +  0.15 , speed +  -0.16 } ,
+				{    mid +  -0.09 , depth +  -0.07 ,  low  +  0.08 , yaw +  -0.15 , speed +  -0.14 } ,
+				{    mid +  0.22 , depth +  -0.06 ,  heigh  +  -0.06 , yaw +  0.04 , speed +  0.18 } ,
+				{    mid +  0.03 , depth +  0.19 ,  low  +  0.19 , yaw +  -0.04 , speed +  0.19 } ,
+				{    mid +  -0.26 , depth +  0.0 ,  heigh  +  0.01 , yaw +  0.03 , speed +  0.08 } ,
+				{    mid +  -0.09 , depth +  -0.19 ,  low  +  -0.11 , yaw +  -0.17 , speed +  -0.05 } ,
+				{    mid +  0.28 , depth +  0.03 ,  heigh  +  0.15 , yaw +  -0.12 , speed +  0.09 } ,
+				{    mid +  -0.01 , depth +  0.15 ,  low  +  -0.14 , yaw +  0.05 , speed +  0.02 } ,
+				{    mid +  -0.02 , depth +  -0.12 ,  heigh  +  -0.12 , yaw +  -0.06 , speed +  0.01 } ,
+				{    mid +  -0.26 , depth +  -0.11 ,  low  +  -0.06 , yaw +  0.08 , speed +  0.06 } ,
+				{    mid +  0.09 , depth +  -0.12 ,  heigh  +  -0.14 , yaw +  0.0 , speed +  0.09 } ,
+				{    mid +  0.1 , depth +  0.01 ,  low  +  -0.01 , yaw +  0.19 , speed +  -0.04 } ,
+				{    mid +  0.12 , depth +  -0.13 ,  heigh  +  0.15 , yaw +  -0.04 , speed +  0.12 } ,
+				{    mid +  0.03 , depth +  -0.11 ,  low  +  0.18 , yaw +  0.09 , speed +  -0.11 } ,
+				{    mid +  -0.28 , depth +  0.0 ,  heigh  +  0.07 , yaw +  -0.05 , speed +  -0.12 } ,
+				{    mid +  0.29 , depth +  -0.02 ,  low  +  0.06 , yaw +  -0.02 , speed +  0.01 } ,
+				{    mid +  -0.28 , depth +  0.13 ,  heigh  +  0.09 , yaw +  0.15 , speed +  -0.18 } ,
+				{    mid +  -0.19 , depth +  -0.12 ,  low  +  0.04 , yaw +  0.06 , speed +  0.06 } ,
+				{    mid +  0.04 , depth +  -0.2 ,  heigh  +  0.02 , yaw +  -0.02 , speed +  0.04 } ,
+				{    mid +  0.25 , depth +  0.02 ,  low  +  -0.19 , yaw +  -0.04 , speed +  -0.17 } ,
+				{    mid +  -0.28 , depth +  0.11 ,  heigh  +  -0.03 , yaw +  0.08 , speed +  0.1 } ,
+				{    mid +  0.16 , depth +  0.09 ,  low  +  0.08 , yaw +  0.02 , speed +  -0.04 } ,
+				{    mid +  0.17 , depth +  -0.16 ,  heigh  +  -0.05 , yaw +  -0.12 , speed +  0.16 } ,
+				{    mid +  -0.28 , depth +  -0.19 ,  low  +  -0.11 , yaw +  0.06 , speed +  -0.03 } ,
+				{    mid +  -0.03 , depth +  0.11 ,  heigh  +  0.15 , yaw +  0.1 , speed +  0.18 } ,
+				{    mid +  -0.21 , depth +  0.09 ,  low  +  -0.16 , yaw +  -0.19 , speed +  -0.08 } ,
+				{ 	finalPosition.x(),	finalPosition.y(), 		finalPosition.z(),  	yaw, 0.5 },
 		};
-		
-		double startTime = 0;
+
+		double startTime = start;
 		Point4D endPosition = Point4D.create (path[0][0], path[0][1], path[0][2], yaw);
 		Point4D startPosition;
-		double duration = start;
-		
+//		double duration = start;
+
 		TrajectoryComposite.Builder trajectoryBuilder = TrajectoryComposite.builder();
-		
+
 		if (start > 0) {
 			Hover hoverBeforeBegin = new Hover (initialPosition, start);
 			trajectoryBuilder.addTrajectory(hoverBeforeBegin);
 		}
-		
+
 		StraightLineTrajectory4D line;
-		
+
 		for(int i = 1 ; i < path.length; i++) {
 			double[] lineInfo = path[i];
 			startTime += duration;
@@ -86,16 +87,17 @@ public class NerveTrajectoryIntroduction implements FiniteTrajectory4d {
 			startPosition = endPosition;
 			endPosition = Point4D.create (lineInfo[0], lineInfo[1], lineInfo[2], lineInfo[3]);
 			line = StraightLineTrajectory4D.createWithPercentageVelocity(startPosition, endPosition, spd);
-			duration = line.getTrajectoryDuration();
+			double lineDuration = line.getTrajectoryDuration();
+			startTime += lineDuration;
 			trajectoryBuilder.addTrajectory(line);
 			System.out.println("Trajectory added, duration " + duration);
 		}
-		
+
 		this.duration = startTime;
 		this.trajectory = trajectoryBuilder.build();
 
 	}
-		
+
 	@Override
 	public double getTrajectoryDuration() {
 		return this.duration;

--- a/trajectory/src/main/java/io/github/agentwise/swarmview/trajectory/rats/acts/introduction/TwinDrones.java
+++ b/trajectory/src/main/java/io/github/agentwise/swarmview/trajectory/rats/acts/introduction/TwinDrones.java
@@ -75,7 +75,7 @@ public abstract class TwinDrones {
             FiniteTrajectory4d lastLeg = Trajectories
                     .newStraightLineTrajectory(wp2, this.finalPos, exitVelocity);
 
-            double height = 2;
+            double height = 2.5;
             Point3D dest = Point3D.plus(circleCenterPoint, Point3D.create(0, 0, height));
             double vertSpeed = height / (circleTiming / 2);
             double updatedPhase = phaseToConnectStart + (revolutions * Math.PI); // 2PI * revs/2
@@ -95,7 +95,7 @@ public abstract class TwinDrones {
                     .addTrajectory(firstLeg)
                     .addTrajectory(Trajectories.newHoldPositionTrajectory(wp1))
                     .withDuration(waitAtStation)
-                    .addTrajectory(corkscrewUp).withDuration(circleTiming / 2)
+                    .addTrajectory(corkscrewUp).withDuration(circleTiming / 2 + 2)
                     .addTrajectory(corkscrewDown).withDuration(circleTiming / 2)
                     .addTrajectory(Trajectories.newHoldPositionTrajectory(wp2))
                     .withDuration(waitAtStation).addTrajectory(lastLeg)


### PR DESCRIPTION
- Fix the logic to calculate `startTime` in Nerve's intro. Nerve no longer jumps to the final destination anymore, but follows a straight line.
- Fievel's trajectory is shifted -1 in y coordinate.
- Fix the collision between Romeo and Juliet when they are switching from corkscrewUp to corkscrewDown. The collision is because they start the corkscrewUp at different starting time. Romeo starts earlier and then he goes down (switches to corkscrewDown) earlier, while Juliet is still moving up. It is fixed by adding two seconds to the duration of Romeo's corkscrewUp. Now there is no collision but Romeo will stay still for few seconds after reaching the top of corkscrewUp, which needs to be fixed in the future.
- Fix the collision between Dumbo and Romeo by simply changing Dumbo's wiggle positions.